### PR TITLE
Add support for Start, Connect, Stream, and Trancription twiml verb

### DIFF
--- a/lib/ex_twiml.ex
+++ b/lib/ex_twiml.ex
@@ -63,6 +63,64 @@ defmodule ExTwiml do
       </Response>
 
   You'd then need to render this string to the browser.
+
+  ## Stream Support
+
+  How to start unidirectional streaming (audio fork) with `<Start>` and `<Stream>`:
+
+      twiml do
+        start do
+          stream url: "wss://example.com/audiostream" do
+          end
+        end
+        say "This call is being streamed"
+      end
+
+      # Generates
+      <?xml version="1.0" encoding="UTF-8"?>
+      <Response>
+        <Start>
+          <Stream url="wss://example.com/audiostream"></Stream>
+        </Start>
+        <Say>This call is being streamed</Say>
+      </Response>
+
+  How to use bidirectional streaming with `<Connect>` and `<Stream>`:
+
+      twiml do
+        connect do
+          stream url: "wss://example.com/audiostream" do
+          end
+        end
+      end
+
+      # Note: With Connect, the call waits until the WebSocket is closed
+      # before continuing to the next instruction
+
+  Stream with custom parameters:
+
+      twiml do
+        start do
+          stream url: "wss://transcription.example.com/audio",
+                 name: "call_transcript",
+                 track: "both_tracks",
+                 status_callback: "https://example.com/stream-status" do
+            parameter name: "CallSid", value: call_sid
+            parameter name: "Language", value: "en-US"
+            parameter name: "CustomerId", value: customer_id
+          end
+        end
+        say "This call is being transcribed"
+      end
+
+  Stop a named stream:
+
+      twiml do
+        stop do
+          stream name: "call_transcript" do
+          end
+        end
+      end
   """
 
   import ExTwiml.Utilities
@@ -75,6 +133,10 @@ defmodule ExTwiml do
     :dial,
     :message,
     :task,
+    :start,
+    :connect,
+    :stream,
+    :stop,
 
     # Non-nested
     :say,

--- a/lib/ex_twiml.ex
+++ b/lib/ex_twiml.ex
@@ -137,6 +137,7 @@ defmodule ExTwiml do
     :connect,
     :stream,
     :stop,
+    :transcription,
 
     # Non-nested
     :say,

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule ExTwiml.Mixfile do
     [
       app: :ex_twiml,
       description: "Generate TwiML with Elixir",
-      version: "2.2.3",
+      version: "2.3.3",
       elixir: "~> 1.0",
       deps: deps(),
       dialyzer: [

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -447,8 +447,8 @@ defmodule ExTwimlTest do
       twiml do
         start do
           stream url: "wss://example.com/audio" do
-            parameter name: "CustomerId", value: "12345"
-            parameter name: "SessionId", value: "abc-123"
+            parameter(name: "CustomerId", value: "12345")
+            parameter(name: "SessionId", value: "abc-123")
           end
         end
       end
@@ -478,10 +478,13 @@ defmodule ExTwimlTest do
           stream url: "wss://example.com/audio", name: "call_stream" do
           end
         end
-        say "Recording started"
+
+        say("Recording started")
+
         gather digits: 1 do
-          say "Press 1 to stop recording"
+          say("Press 1 to stop recording")
         end
+
         stop do
           stream name: "call_stream" do
           end
@@ -501,8 +504,8 @@ defmodule ExTwimlTest do
           stream url: "wss://transcription-service.com/audio",
                  name: "call_transcript",
                  track: "both_tracks" do
-            parameter name: "CallSid", value: "CA123456"
-            parameter name: "Language", value: "en-US"
+            parameter(name: "CallSid", value: "CA123456")
+            parameter(name: "Language", value: "en-US")
           end
         end
       end
@@ -530,7 +533,10 @@ defmodule ExTwimlTest do
         end
       end
 
-    assert_twiml(markup, "<Transcription name=\"call_transcript\" language=\"en-US\"></Transcription>")
+    assert_twiml(
+      markup,
+      "<Transcription name=\"call_transcript\" language=\"en-US\"></Transcription>"
+    )
   end
 
   test "can render the <Transcription> verb with track attribute" do
@@ -547,10 +553,10 @@ defmodule ExTwimlTest do
     markup =
       twiml do
         transcription name: "live_transcript",
-                     track: "both_tracks",
-                     language: "en-US",
-                     status_callback: "https://example.com/transcription-status",
-                     status_callback_method: "POST" do
+                      track: "both_tracks",
+                      language: "en-US",
+                      status_callback: "https://example.com/transcription-status",
+                      status_callback_method: "POST" do
         end
       end
 
@@ -569,16 +575,19 @@ defmodule ExTwimlTest do
         end
       end
 
-    assert_twiml(markup, "<Start><Transcription name=\"call_transcript\" language=\"en-US\"></Transcription></Start>")
+    assert_twiml(
+      markup,
+      "<Start><Transcription name=\"call_transcript\" language=\"en-US\"></Transcription></Start>"
+    )
   end
 
   test "can render <Transcription> with nested <Parameter> elements" do
     markup =
       twiml do
         transcription name: "call_transcript" do
-          parameter name: "CallSid", value: "CA123456"
-          parameter name: "AccountSid", value: "AC789012"
-          parameter name: "CustomField", value: "custom_value"
+          parameter(name: "CallSid", value: "CA123456")
+          parameter(name: "AccountSid", value: "AC789012")
+          parameter(name: "CustomField", value: "custom_value")
         end
       end
 
@@ -594,6 +603,7 @@ defmodule ExTwimlTest do
         start do
           transcription name: "inbound_transcript", track: "inbound_track" do
           end
+
           transcription name: "outbound_transcript", track: "outbound_track" do
           end
         end
@@ -610,16 +620,19 @@ defmodule ExTwimlTest do
       twiml do
         start do
           transcription name: "live_call_transcript",
-                       language: "en-US",
-                       track: "both_tracks" do
-            parameter name: "CallSid", value: "CA123456"
-            parameter name: "CustomerName", value: "John Doe"
+                        language: "en-US",
+                        track: "both_tracks" do
+            parameter(name: "CallSid", value: "CA123456")
+            parameter(name: "CustomerName", value: "John Doe")
           end
         end
-        say "This call is being transcribed for quality assurance"
+
+        say("This call is being transcribed for quality assurance")
+
         gather digits: 1 do
-          say "Press 1 to stop transcription"
+          say("Press 1 to stop transcription")
         end
+
         stop do
           transcription name: "live_call_transcript" do
           end
@@ -636,11 +649,14 @@ defmodule ExTwimlTest do
     markup =
       twiml do
         transcription name: "filtered_transcript",
-                     profanity_filter: true do
+                      profanity_filter: true do
         end
       end
 
-    assert_twiml(markup, "<Transcription name=\"filtered_transcript\" profanityFilter=\"true\"></Transcription>")
+    assert_twiml(
+      markup,
+      "<Transcription name=\"filtered_transcript\" profanityFilter=\"true\"></Transcription>"
+    )
   end
 
   test "can render <Transcription> with options as a variable" do
@@ -652,7 +668,10 @@ defmodule ExTwimlTest do
         end
       end
 
-    assert_twiml(markup, "<Transcription name=\"dynamic_transcript\" language=\"es-ES\" track=\"inbound_track\"></Transcription>")
+    assert_twiml(
+      markup,
+      "<Transcription name=\"dynamic_transcript\" language=\"es-ES\" track=\"inbound_track\"></Transcription>"
+    )
   end
 
   defp assert_twiml(lhs, rhs) do

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -399,6 +399,120 @@ defmodule ExTwimlTest do
     assert_twiml(markup, "<Mms to=\"112345&apos;\">hello</Mms>")
   end
 
+  test "can render the <Start> verb with <Stream>" do
+    markup =
+      twiml do
+        start do
+          stream url: "wss://example.com/audio" do
+          end
+        end
+      end
+
+    assert_twiml(markup, "<Start><Stream url=\"wss://example.com/audio\"></Stream></Start>")
+  end
+
+  test "can render the <Connect> verb with <Stream>" do
+    markup =
+      twiml do
+        connect do
+          stream url: "wss://example.com/audio" do
+          end
+        end
+      end
+
+    assert_twiml(markup, "<Connect><Stream url=\"wss://example.com/audio\"></Stream></Connect>")
+  end
+
+  test "can render <Stream> with all attributes" do
+    markup =
+      twiml do
+        start do
+          stream url: "wss://example.com/audio",
+                 name: "my_stream",
+                 track: "both_tracks",
+                 status_callback: "https://example.com/callback",
+                 status_callback_method: "GET" do
+          end
+        end
+      end
+
+    assert_twiml(
+      markup,
+      "<Start><Stream url=\"wss://example.com/audio\" name=\"my_stream\" track=\"both_tracks\" statusCallback=\"https://example.com/callback\" statusCallbackMethod=\"GET\"></Stream></Start>"
+    )
+  end
+
+  test "can render <Stream> with nested <Parameter> elements" do
+    markup =
+      twiml do
+        start do
+          stream url: "wss://example.com/audio" do
+            parameter name: "CustomerId", value: "12345"
+            parameter name: "SessionId", value: "abc-123"
+          end
+        end
+      end
+
+    assert_twiml(
+      markup,
+      "<Start><Stream url=\"wss://example.com/audio\"><Parameter name=\"CustomerId\" value=\"12345\" /><Parameter name=\"SessionId\" value=\"abc-123\" /></Stream></Start>"
+    )
+  end
+
+  test "can render the <Stop> verb with <Stream>" do
+    markup =
+      twiml do
+        stop do
+          stream name: "my_stream" do
+          end
+        end
+      end
+
+    assert_twiml(markup, "<Stop><Stream name=\"my_stream\"></Stream></Stop>")
+  end
+
+  test "can render a complete stream flow" do
+    markup =
+      twiml do
+        start do
+          stream url: "wss://example.com/audio", name: "call_stream" do
+          end
+        end
+        say "Recording started"
+        gather digits: 1 do
+          say "Press 1 to stop recording"
+        end
+        stop do
+          stream name: "call_stream" do
+          end
+        end
+      end
+
+    assert_twiml(
+      markup,
+      "<Start><Stream url=\"wss://example.com/audio\" name=\"call_stream\"></Stream></Start><Say>Recording started</Say><Gather digits=\"1\"><Say>Press 1 to stop recording</Say></Gather><Stop><Stream name=\"call_stream\"></Stream></Stop>"
+    )
+  end
+
+  test "can render <Stream> with parameters and attributes" do
+    markup =
+      twiml do
+        start do
+          stream url: "wss://transcription-service.com/audio",
+                 name: "call_transcript",
+                 track: "both_tracks" do
+            parameter name: "CallSid", value: "CA123456"
+            parameter name: "Language", value: "en-US"
+          end
+        end
+      end
+
+    assert_twiml(
+      markup,
+      "<Start><Stream url=\"wss://transcription-service.com/audio\" name=\"call_transcript\" track=\"both_tracks\"><Parameter name=\"CallSid\" value=\"CA123456\" /><Parameter name=\"Language\" value=\"en-US\" /></Stream></Start>"
+    )
+  end
+
   defp assert_twiml(lhs, rhs) do
     assert lhs == "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response>#{rhs}</Response>"
   end

--- a/test/ex_twiml_test.exs
+++ b/test/ex_twiml_test.exs
@@ -513,6 +513,148 @@ defmodule ExTwimlTest do
     )
   end
 
+  test "can render the <Transcription> verb" do
+    markup =
+      twiml do
+        transcription do
+        end
+      end
+
+    assert_twiml(markup, "<Transcription></Transcription>")
+  end
+
+  test "can render the <Transcription> verb with attributes" do
+    markup =
+      twiml do
+        transcription name: "call_transcript", language: "en-US" do
+        end
+      end
+
+    assert_twiml(markup, "<Transcription name=\"call_transcript\" language=\"en-US\"></Transcription>")
+  end
+
+  test "can render the <Transcription> verb with track attribute" do
+    markup =
+      twiml do
+        transcription track: "inbound_track" do
+        end
+      end
+
+    assert_twiml(markup, "<Transcription track=\"inbound_track\"></Transcription>")
+  end
+
+  test "can render the <Transcription> verb with all common attributes" do
+    markup =
+      twiml do
+        transcription name: "live_transcript",
+                     track: "both_tracks",
+                     language: "en-US",
+                     status_callback: "https://example.com/transcription-status",
+                     status_callback_method: "POST" do
+        end
+      end
+
+    assert_twiml(
+      markup,
+      "<Transcription name=\"live_transcript\" track=\"both_tracks\" language=\"en-US\" statusCallback=\"https://example.com/transcription-status\" statusCallbackMethod=\"POST\"></Transcription>"
+    )
+  end
+
+  test "can render <Transcription> nested inside <Start>" do
+    markup =
+      twiml do
+        start do
+          transcription name: "call_transcript", language: "en-US" do
+          end
+        end
+      end
+
+    assert_twiml(markup, "<Start><Transcription name=\"call_transcript\" language=\"en-US\"></Transcription></Start>")
+  end
+
+  test "can render <Transcription> with nested <Parameter> elements" do
+    markup =
+      twiml do
+        transcription name: "call_transcript" do
+          parameter name: "CallSid", value: "CA123456"
+          parameter name: "AccountSid", value: "AC789012"
+          parameter name: "CustomField", value: "custom_value"
+        end
+      end
+
+    assert_twiml(
+      markup,
+      "<Transcription name=\"call_transcript\"><Parameter name=\"CallSid\" value=\"CA123456\" /><Parameter name=\"AccountSid\" value=\"AC789012\" /><Parameter name=\"CustomField\" value=\"custom_value\" /></Transcription>"
+    )
+  end
+
+  test "can render multiple <Transcription> verbs" do
+    markup =
+      twiml do
+        start do
+          transcription name: "inbound_transcript", track: "inbound_track" do
+          end
+          transcription name: "outbound_transcript", track: "outbound_track" do
+          end
+        end
+      end
+
+    assert_twiml(
+      markup,
+      "<Start><Transcription name=\"inbound_transcript\" track=\"inbound_track\"></Transcription><Transcription name=\"outbound_transcript\" track=\"outbound_track\"></Transcription></Start>"
+    )
+  end
+
+  test "can render a complete transcription flow" do
+    markup =
+      twiml do
+        start do
+          transcription name: "live_call_transcript",
+                       language: "en-US",
+                       track: "both_tracks" do
+            parameter name: "CallSid", value: "CA123456"
+            parameter name: "CustomerName", value: "John Doe"
+          end
+        end
+        say "This call is being transcribed for quality assurance"
+        gather digits: 1 do
+          say "Press 1 to stop transcription"
+        end
+        stop do
+          transcription name: "live_call_transcript" do
+          end
+        end
+      end
+
+    assert_twiml(
+      markup,
+      "<Start><Transcription name=\"live_call_transcript\" language=\"en-US\" track=\"both_tracks\"><Parameter name=\"CallSid\" value=\"CA123456\" /><Parameter name=\"CustomerName\" value=\"John Doe\" /></Transcription></Start><Say>This call is being transcribed for quality assurance</Say><Gather digits=\"1\"><Say>Press 1 to stop transcription</Say></Gather><Stop><Transcription name=\"live_call_transcript\"></Transcription></Stop>"
+    )
+  end
+
+  test "can render <Transcription> with profanity filter" do
+    markup =
+      twiml do
+        transcription name: "filtered_transcript",
+                     profanity_filter: true do
+        end
+      end
+
+    assert_twiml(markup, "<Transcription name=\"filtered_transcript\" profanityFilter=\"true\"></Transcription>")
+  end
+
+  test "can render <Transcription> with options as a variable" do
+    options = [name: "dynamic_transcript", language: "es-ES", track: "inbound_track"]
+
+    markup =
+      twiml do
+        transcription options do
+        end
+      end
+
+    assert_twiml(markup, "<Transcription name=\"dynamic_transcript\" language=\"es-ES\" track=\"inbound_track\"></Transcription>")
+  end
+
   defp assert_twiml(lhs, rhs) do
     assert lhs == "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Response>#{rhs}</Response>"
   end


### PR DESCRIPTION
# Add Support for Media Streaming and Live Transcription Verbs

## Summary

This PR adds comprehensive support for Twilio's Media Streams API by implementing five essential verbs: `<Start>`, `<Connect>`, `<Stream>`, `<Stop>`, and `<Transcription>`. These verbs enable real-time audio streaming, bidirectional media connections, and live call transcription capabilities in the ExTwiml library.

## Motivation

Twilio's Media Streams API provides powerful real-time audio processing capabilities that are essential for modern voice applications. Without native support for these verbs in ExTwiml, Elixir developers would need to manually construct XML or use alternative libraries. This PR brings ExTwiml up to date with Twilio's latest streaming capabilities, enabling:

- **Real-time audio streaming** for analytics and processing
- **Live call transcription** for accessibility and insights
- **Bidirectional media streams** for advanced voice applications
- **WebSocket-based audio forking** for parallel processing
- **Voice AI integrations** with streaming transcription

## Changes

### Core Library (`lib/ex_twiml.ex`)
Added five new verbs to the supported nested verbs list:
- `:start` - Initiates unidirectional media streaming (audio fork)
- `:connect` - Establishes bidirectional media streaming connections
- `:stream` - Configures WebSocket streaming endpoints
- `:stop` - Terminates active streams
- `:transcription` - Enables real-time speech-to-text transcription

No additional implementation required - the existing macro system handles all functionality seamlessly.

### Test Suite (`test/ex_twiml_test.exs`)
Added comprehensive test coverage including:
- Stream initiation and configuration tests
- Transcription rendering with various attributes
- Nested parameter support for custom metadata
- Integration scenarios combining multiple verbs
- Real-world usage patterns

## Usage Examples

### Basic Audio Streaming
```elixir
twiml do
  start do
    stream url: "wss://example.com/audiostream" do
    end
  end
  say "This call is being streamed"
end
```

### Bidirectional Media Connection
```elixir
twiml do
  connect do
    stream url: "wss://example.com/mediastream",
           name: "voice_assistant" do
      parameter name: "SessionId", value: session_id
    end
  end
end
```

### Live Transcription with Streaming
```elixir
twiml do
  start do
    # Start audio streaming
    stream url: "wss://analytics.example.com/audio",
           name: "call_analytics",
           track: "both_tracks" do
      parameter name: "CallSid", value: call_sid
    end
    
    # Start transcription
    transcription name: "live_transcript",
                 language: "en-US",
                 track: "both_tracks",
                 profanity_filter: true do
      parameter name: "CustomerName", value: customer_name
    end
  end
  
  say "Your call is being recorded and transcribed"
  
  # ... rest of call logic ...
  
  stop do
    stream name: "call_analytics" do
    end
    transcription name: "live_transcript" do
    end
  end
end
```

### Stream with Custom Parameters
```elixir
twiml do
  start do
    stream url: "wss://ai.example.com/process",
           name: "ai_processor",
           track: "inbound_track",
           status_callback: "https://example.com/stream-status",
           status_callback_method: "POST" do
      parameter name: "Model", value: "gpt-4"
      parameter name: "Temperature", value: "0.7"
      parameter name: "Language", value: "en-US"
    end
  end
end
```

## Supported Verbs and Attributes

### `<Start>` / `<Stop>`
Control verbs for managing stream lifecycle. `<Start>` initiates streams, `<Stop>` terminates them.

### `<Connect>`
Creates bidirectional WebSocket connections that pause call execution until disconnected.

### `<Stream>`
Attributes:
- `url` - WebSocket endpoint URL (required)
- `name` - Unique identifier for the stream
- `track` - Audio track selection ("inbound_track", "outbound_track", "both_tracks")
- `status_callback` - URL for stream status updates
- `status_callback_method` - HTTP method for callbacks

### `<Transcription>`
Attributes:
- `name` - Unique identifier for the transcription stream
- `language` - BCP-47 language code (e.g., "en-US", "es-ES")
- `track` - Audio track to transcribe
- `profanity_filter` - Enable/disable profanity filtering
- `status_callback` - URL for transcription status updates
- `status_callback_method` - HTTP method for callbacks

### `<Parameter>`
Used within `<Stream>` and `<Transcription>` to pass custom metadata:
- `name` - Parameter name
- `value` - Parameter value

## Testing

All tests pass:
```bash
mix test test/ex_twiml_test.exs
```

The test suite includes:
- ✅ Basic verb rendering for all new verbs
- ✅ Attribute handling and XML escaping
- ✅ Nested parameter support
- ✅ Complex integration scenarios
- ✅ Stream lifecycle management
- ✅ Transcription configuration options

## Backwards Compatibility

This change is fully backwards compatible. It only adds new functionality without modifying any existing behavior.

## Documentation

All new verbs follow the same patterns as existing nested verbs in the ExTwiml DSL. The module documentation has been updated with examples showing how to use the streaming capabilities.

## Related Links

- [Twilio Media Streams Documentation](https://www.twilio.com/docs/voice/media-streams)
- [Twilio Transcription Documentation](https://www.twilio.com/docs/voice/twiml/transcription)
- [Stream TwiML Reference](https://www.twilio.com/docs/voice/twiml/stream)
- [Connect TwiML Reference](https://www.twilio.com/docs/voice/twiml/connect)

## Checklist

- [x] All five streaming verbs implemented
- [x] Tests added and passing
- [x] No breaking changes
- [x] Follows existing code patterns
- [x] Supports all Twilio attributes
- [x] Documentation examples included
- [x] Ready for review 